### PR TITLE
Make view page of ZSet more readable.

### DIFF
--- a/view.php
+++ b/view.php
@@ -264,6 +264,7 @@ else if ($type == 'zset') { ?>
 ?>
   <tr <?php echo $alt ? 'class="alt"' : ''?>><td><div><?php echo $score?></div></td><td><div><?php echo $display_value ?></div></td><td><div>
     <a href="edit.php?s=<?php echo $server['id']?>&amp;d=<?php echo $server['db']?>&amp;type=zset&amp;key=<?php echo urlencode($_GET['key'])?>&amp;score=<?php echo $score?>&amp;value=<?php echo urlencode($value)?>"><img src="images/edit.png" width="16" height="16" title="Edit" alt="[E]"></a>
+  </div></td><td><div>
     <a href="delete.php?s=<?php echo $server['id']?>&amp;d=<?php echo $server['db']?>&amp;type=zset&amp;key=<?php echo urlencode($_GET['key'])?>&amp;value=<?php echo urlencode($value)?>" class="delval"><img src="images/delete.png" width="16" height="16" title="Delete" alt="[X]"></a>
   </div></td></tr>
 <?php $alt = !$alt; } ?>


### PR DESCRIPTION
While a zset has long values, the edit and delete action will line vertically, so it occupy two lines space.

I notice that view of other data types display well, so just copy a line from else where.

Hope it useful for others.

Thanks a lot.